### PR TITLE
Removed deprecated stuff from usage where possible

### DIFF
--- a/source/raylib/package.d
+++ b/source/raylib/package.d
@@ -78,6 +78,7 @@
 module raylib;
 import core.stdc.config;
 import core.stdc.stdarg;
+import std.math;
 
 extern (C) @nogc nothrow:
 
@@ -98,9 +99,9 @@ enum RAYLIB_VERSION = "4.0";
 
 deprecated("Use std.math.PI instead.") enum PI = 3.14159265358979323846f;
 
-enum DEG2RAD = PI / 180.0f;
+enum DEG2RAD = std.math.PI / 180.0f;
 
-enum RAD2DEG = 180.0f / PI;
+enum RAD2DEG = 180.0f / std.math.PI;
 
 // NOTE: We set some defines with some data types declared by raylib
 // Other modules (raymath, rlgl) also require some of those types, so,

--- a/source/raylib/raymath.d
+++ b/source/raylib/raymath.d
@@ -63,8 +63,9 @@ extern (C) @nogc nothrow:
 // Defines and Macros
 //----------------------------------------------------------------------------------
 
-public import raylib: PI, DEG2RAD, RAD2DEG, Vector2, Vector3, Vector4, Quaternion, Matrix;
+public import raylib: DEG2RAD, RAD2DEG, Vector2, Vector3, Vector4, Quaternion, Matrix;
 import core.stdc.math;
+import std.math: PI;
 /+enum PI = 3.14159265358979323846f;
 
 enum DEG2RAD = PI / 180.0f;


### PR DESCRIPTION
This micro PR removes the use of the deprecated constant raylib.PI. I made this PR in order to refamiliarize myself with the raylib code and get my feet wet after many weeks of not really touching code. I didn't touch the deprecated usage of raylib's GetWorkingDirectory and GetFileExtension functions since they seem to involve retouching the logic of the code a bit and we decided that rewriting stuff in the D way should wait until a later phase of the project.